### PR TITLE
docs: highlight recommended bot component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This is a custom component for [Home Assistant](https://www.home-assistant.io) that allows sending and receiving messages through [Nextcloud Talk](https://nextcloud.com/talk/).
 
+> [!TIP]
+> Looking for a more full-featured solution? Check out the actively maintained [Nextcloud Talk Bot Component](https://github.com/klatka/nc-talk-bot-component/releases), which expands on the capabilities of this integration and may be a better fit for your setup.
+
 ## Features
 
 - Send messages to Nextcloud Talk channels using the Nextcloud OCS API.


### PR DESCRIPTION
## Summary
- add a tip to the README pointing users to the more feature-rich Nextcloud Talk Bot Component releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690b9fd3c7588327b8f70c35e06105de